### PR TITLE
feat: add ISSUE TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,1 +1,0 @@
-<!--- Provide a general summary of the issue in the Title above -->

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug Report (Traefik)
+description: Create a report to help us improve.
+body:
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Welcome!
+      description: |
+        The issue tracker is for reporting bugs and feature requests only.
+        For end-user related support questions, please use the [Traefik community forum](https://community.traefik.io/).
+
+        All new/updated issues are triaged regularly by the maintainers.
+        All issues closed by a bot are subsequently double-checked by the maintainers.
+
+        DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
+
+      options:
+        - label: Yes, I've searched similar issues on [GitHub](https://github.com/traefik/traefik/issues) and didn't find any.
+          required: true
+        - label: Yes, I've searched similar issues on the [Traefik community forum](https://community.traefik.io) and didn't find any.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: What did you do?
+      description: |
+        How to write a good bug report?
+
+        - Respect the issue template as much as possible.
+        - The title should be short and descriptive.
+        - Explain the conditions which led you to report this issue: the context.
+        - The context should lead to something, an idea or a problem that you’re facing.
+        - Remain clear and concise.
+        - Format your messages to help the reader focus on what matters and understand the structure of your message, use [Markdown syntax](https://help.github.com/articles/github-flavored-markdown)
+      placeholder: What did you do?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What were you expecting?
+      placeholder: What were you expecting?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What version of Traefik are you using?
+      description: |
+        `latest` is not considered as a valid version.
+
+        Output of `traefik version`.
+
+        For the Traefik Docker image (`docker run [IMAGE] version`), example:
+        ```console
+        $ docker run traefik version
+        ```
+      placeholder: Paste your output here.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What is your environment & configuration?
+      description: arguments, toml, provider, platform, ...
+      placeholder: Add information here.
+      value: |
+        ```yaml
+        # (paste your configuration here)
+        ```
+
+        Add more configuration information here.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: If applicable, please paste the log output in DEBUG level
+      description: "`--log.level=DEBUG` switch."
+      placeholder: Paste your output here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: Bug Report (Traefik)
+name: Bug Report
 description: Create a report to help us improve.
 body:
   - type: checkboxes
@@ -7,7 +7,6 @@ body:
       label: Welcome!
       description: |
         The issue tracker is for reporting bugs and feature requests only.
-        For end-user related support questions, please use the [Traefik community forum](https://community.traefik.io/).
 
         All new/updated issues are triaged regularly by the maintainers.
         All issues closed by a bot are subsequently double-checked by the maintainers.
@@ -15,9 +14,7 @@ body:
         DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
 
       options:
-        - label: Yes, I've searched similar issues on [GitHub](https://github.com/traefik/traefik/issues) and didn't find any.
-          required: true
-        - label: Yes, I've searched similar issues on the [Traefik community forum](https://community.traefik.io) and didn't find any.
+        - label: Yes, I've searched similar issues on [GitHub](https://github.com/traefik/hub/issues) and didn't find any.
           required: true
 
   - type: textarea
@@ -45,16 +42,9 @@ body:
 
   - type: textarea
     attributes:
-      label: What version of Traefik are you using?
+      label: What version are you using?
       description: |
         `latest` is not considered as a valid version.
-
-        Output of `traefik version`.
-
-        For the Traefik Docker image (`docker run [IMAGE] version`), example:
-        ```console
-        $ docker run traefik version
-        ```
       placeholder: Paste your output here.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Traefik Community Support
+    url: https://community.traefik.io/
+    about: If you have a question, or are looking for advice, please post on our Discuss forum! The community loves to chime in to help. Happy Coding!

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature Request (Traefik)
+description: Suggest an idea for this project.
+body:
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Welcome!
+      description: |
+        The issue tracker is for reporting bugs and feature requests only. For end-user related support questions, please refer to one of the following:
+        - the Traefik community forum: https://community.traefik.io/
+
+        DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
+      options:
+        - label: Yes, I've searched similar issues on [GitHub](https://github.com/traefik/traefik/issues) and didn't find any.
+          required: true
+        - label: Yes, I've searched similar issues on the [Traefik community forum](https://community.traefik.io) and didn't find any.
+          required: true
+
+  - type: textarea
+    attributes:
+      label: What did you expect to see?
+      description: |
+        How to write a good issue?
+
+        - Respect the issue template as much as possible.
+        - The title should be short and descriptive.
+        - Explain the conditions which led you to report this issue: the context.
+        - The context should lead to something, an idea or a problem that you’re facing.
+        - Remain clear and concise.
+        - Format your messages to help the reader focus on what matters and understand the structure of your message, use [Markdown syntax](https://help.github.com/articles/github-flavored-markdown)
+      placeholder: What did you expect to see?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,4 @@
-name: Feature Request (Traefik)
+name: Feature Request
 description: Suggest an idea for this project.
 body:
   - type: checkboxes
@@ -6,14 +6,11 @@ body:
     attributes:
       label: Welcome!
       description: |
-        The issue tracker is for reporting bugs and feature requests only. For end-user related support questions, please refer to one of the following:
-        - the Traefik community forum: https://community.traefik.io/
+        The issue tracker is for reporting bugs and feature requests only.
 
         DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
       options:
-        - label: Yes, I've searched similar issues on [GitHub](https://github.com/traefik/traefik/issues) and didn't find any.
-          required: true
-        - label: Yes, I've searched similar issues on the [Traefik community forum](https://community.traefik.io) and didn't find any.
+        - label: Yes, I've searched similar issues on [GitHub](https://github.com/traefik/hub/issues) and didn't find any.
           required: true
 
   - type: textarea


### PR DESCRIPTION
### Motivation

limit spam.

Upstream doc is [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository).
