### PR TITLE
chore(ci): replace buildjet runner

### DIFF
--- a/.github/workflows/api-server.yaml
+++ b/.github/workflows/api-server.yaml
@@ -26,7 +26,7 @@ jobs:
       contents: read
       pull-requests: read
       packages: write
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     name: "${{ github.event_name == 'pull_request' && 'build ' || 'release' }} image"
     steps:
       - name: checkout

--- a/.github/workflows/api-server.yaml
+++ b/.github/workflows/api-server.yaml
@@ -3,13 +3,13 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - '.github/workflows/api-server.yaml'
       - 'src/api-server/**'
   push:
     branches:
-      - master
+      - main
     paths:
       - '.github/workflows/api-server.yaml'
       - 'src/api-server/**'


### PR DESCRIPTION
### Motivation

BuildJet for GitHub Actions is shutting down [[ref.](https://buildjet.com/for-github-actions/blog/we-are-shutting-down)]
