### PR TITLE
docs: rewrite README with guide collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <br />
 
-This repository primarily hosts the release artifacts for **Traefik Hub** and the **[Traefik Hub Static Analyzer](https://doc.traefik.io/traefik-hub/static-analyzer)**. Follow the guides below to start exploring Traefik Hub.
+This repository primarily hosts the release artifacts for [Traefik Hub](https://traefik.io/traefik-hub) and the **[Traefik Hub Static Analyzer](https://doc.traefik.io/traefik-hub/static-analyzer)**. Follow the guides below to start exploring Traefik Hub.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,45 +15,60 @@
 
 <br />
 
-<div align="center"><strong>Traefik Hub</strong>
+This repository primarily hosts the release artifacts for **Traefik Hub** and the **[Traefik Hub Static Analyzer](https://doc.traefik.io/traefik-hub/static-analyzer)**. Follow the guides below to start exploring Traefik Hub.
 
-<br />
-<br />
-</div>
+---
 
-<div align="center">Welcome to this repository!</div>
+## API Gateway
 
-## :information_source: About
+- [Getting Started](https://doc.traefik.io/traefik-hub/api-gateway/getting-started)
+- [Installation](https://doc.traefik.io/traefik-hub/api-gateway/setup/kubernetes/installation)
+- [Traffic Management](https://doc.traefik.io/traefik-hub/api-gateway/expose/expose-overview)
+- [Expose APIs](https://doc.traefik.io/traefik-hub/api-gateway/expose/routers)
+- [Security Overview](https://doc.traefik.io/traefik-hub/api-gateway/secure/secure-overview)
+- [TLS Encryption](https://doc.traefik.io/traefik-hub/api-gateway/secure/tls/secure-overview-tls)
+- [Access Control](https://doc.traefik.io/traefik-hub/api-gateway/secure/middleware/secure-middleware-overview)
+- [Observability & Monitoring](https://doc.traefik.io/traefik-hub/api-gateway/observability/metrics-tracing-logs)
 
-This repository contains source code showing how to use:
+### Cloud Providers
 
-1. Traefik Hub API Gateway
-2. Traefik Hub API Management
+**Linode Kubernetes Engine**
+- [Deploy Traefik Hub on LKE](https://doc.traefik.io/traefik-hub/api-gateway/setup/installation/lke)
 
+**Nutanix Kubernetes Platform**
+- [Deploy Traefik Hub on NKP](https://doc.traefik.io/traefik-hub/api-gateway/setup/installation/nkp)
 
-## :alembic: APIs used in this repository
+**Oracle Cloud Infrastructure**
+- [Deploy Traefik Hub from Oracle Marketplace](https://doc.traefik.io/traefik-hub/api-gateway/setup/installation/oracle-oci/oci-marketplace)
 
-All APIs are implemented using a tiny JSON server in Go; the source code is [here](./src/api-server).
+## API Management
 
-This JSON server is used to deploy JSON APIs using a configmap.
+- [Getting Started](https://doc.traefik.io/traefik-hub/api-management/quick-start-guide)
+- [Manage APIs](https://doc.traefik.io/traefik-hub/api-management/api)
+- [API Authentication](https://doc.traefik.io/traefik-hub/api-management/api-auth)
+- [API Plans](https://doc.traefik.io/traefik-hub/api-management/api-plans)
+- [API Portal](https://doc.traefik.io/traefik-hub/api-management/api-portal)
+- [External APIs](https://doc.traefik.io/traefik-hub/api-management/catalog-external-apis)
+- [Self-Service Subscriptions](https://doc.traefik.io/traefik-hub/api-management/self-service-subscription)
+- [User Management](https://doc.traefik.io/traefik-hub/api-management/users-and-groups)
 
-The Kubernetes manifests (YAML) to deploy those apps are [here](./src/manifests).
+### Cloud Providers
 
-## :construction_worker: Where to start ?
+**Azure**
+- [Deploy Traefik Hub API Management on Azure Arc](https://doc.traefik.io/traefik-hub/operations/azure/azure-arc-apim)
 
-The journey can start [here](WALKTHROUGH.md) for a quickstart with a global overview
+**Oracle Cloud Infrastructure**
+- [Deploy Traefik Hub API Management From Oracle OCI Marketplace](https://doc.traefik.io/traefik-hub/operations/oracle-oci/oci-apim-marketplace)
+- [Deploy and Configure Traefik Hub Using OCI DevOps](https://doc.traefik.io/traefik-hub/operations/oracle-oci/oci-devops)
+- [External API Integration with OCI](https://doc.traefik.io/traefik-hub/operations/oracle-oci/external-api-integration)
+- [Configure OCI Logging for Traefik Hub](https://doc.traefik.io/traefik-hub/operations/oracle-oci/oci-logging)
+- [Configure Oracle APM for Traefik Hub](https://doc.traefik.io/traefik-hub/operations/oracle-oci/oci-apm)
 
-## 📒 Repository Structure
+## AI Gateway
 
-```shell
-.
-├── api-gateway                       # Traefik Hub API Gateway tutorials
-│   ├── 1-getting-started  # API Gateway Quick Start Guide
-│   ├── 2-expose
-│   ├── 3-secure-applications
-├── api-management                    # Traefik Hub API Management tutorials
-│   ├── 1-getting-started # API Management Quick Start Guide
-└── src
-    ├── api-server                    # API server source code
-    └── manifests                     # Yaml to deploy all apps
-```
+- [Overview](https://doc.traefik.io/traefik-hub/ai-gateway/overview)
+- [Chat Completion](https://doc.traefik.io/traefik-hub/ai-gateway/middlewares/chat-completion)
+- [Semantic Cache](https://doc.traefik.io/traefik-hub/ai-gateway/middlewares/semantic-cache)
+- [Content Guard](https://doc.traefik.io/traefik-hub/ai-gateway/middlewares/content-guard)
+- [LLM Guard](https://doc.traefik.io/traefik-hub/ai-gateway/middlewares/llm-guard)
+- [AI Gateway Failover](https://doc.traefik.io/traefik-hub/ai-gateway/guides/ai-gateway-failover)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This repository primarily hosts the release artifacts for **[Traefik Hub](https:
 - [External APIs](https://doc.traefik.io/traefik-hub/api-management/catalog-external-apis)
 - [Self-Service Subscriptions](https://doc.traefik.io/traefik-hub/api-management/self-service-subscription)
 - [User Management](https://doc.traefik.io/traefik-hub/api-management/users-and-groups)
+- [API Mocking](https://doc.traefik.io/traefik-hub/api-mocking/on-premises-setup)
 
 ### Cloud Providers
 
@@ -72,3 +73,8 @@ This repository primarily hosts the release artifacts for **[Traefik Hub](https:
 - [Content Guard](https://doc.traefik.io/traefik-hub/ai-gateway/middlewares/content-guard)
 - [LLM Guard](https://doc.traefik.io/traefik-hub/ai-gateway/middlewares/llm-guard)
 - [AI Gateway Failover](https://doc.traefik.io/traefik-hub/ai-gateway/guides/ai-gateway-failover)
+
+## MCP Gateway
+
+- [Overview](https://doc.traefik.io/traefik-hub/mcp-gateway/mcp)
+- [Getting Started](https://doc.traefik.io/traefik-hub/mcp-gateway/guides/getting-started)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 <br />
 
-This repository primarily hosts the release artifacts for [Traefik Hub](https://traefik.io/traefik-hub) and the **[Traefik Hub Static Analyzer](https://doc.traefik.io/traefik-hub/static-analyzer)**. Follow the guides below to start exploring Traefik Hub.
+This repository primarily hosts the release artifacts for **[Traefik Hub](https://traefik.io/traefik-hub)** and the **[Traefik Hub Static Analyzer](https://doc.traefik.io/traefik-hub/static-analyzer)**. Follow the guides below to start exploring Traefik Hub.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository primarily hosts the release artifacts for [Traefik Hub](https://
 ## API Gateway
 
 - [Getting Started](https://doc.traefik.io/traefik-hub/api-gateway/getting-started)
-- [Installation](https://doc.traefik.io/traefik-hub/api-gateway/setup/kubernetes/installation)
+- [Kubernetes Installation](https://doc.traefik.io/traefik-hub/api-gateway/setup/kubernetes/installation)
 - [Traffic Management](https://doc.traefik.io/traefik-hub/api-gateway/expose/expose-overview)
 - [Expose APIs](https://doc.traefik.io/traefik-hub/api-gateway/expose/routers)
 - [Security Overview](https://doc.traefik.io/traefik-hub/api-gateway/secure/secure-overview)

--- a/README.md
+++ b/README.md
@@ -78,3 +78,5 @@ This repository primarily hosts the release artifacts for **[Traefik Hub](https:
 
 - [Overview](https://doc.traefik.io/traefik-hub/mcp-gateway/mcp)
 - [Getting Started](https://doc.traefik.io/traefik-hub/mcp-gateway/guides/getting-started)
+- [Understanding TBAC](https://doc.traefik.io/traefik-hub/mcp-gateway/guides/understanding-tbac)
+- [MCP Best Practices](https://doc.traefik.io/traefik-hub/mcp-gateway/guides/mcp-gateway-best-practices)


### PR DESCRIPTION
Replaces the outdated README content with a curated list of guides in the live docs organized by product area  
- API Gateway, 
- API Management
- AI Gateway

Also clarifies that the repo primarily hosts Traefik Hub and Static Analyzer release artifacts.